### PR TITLE
folder permissions fix at create_course_dirs func

### DIFF
--- a/modules/create_course/functions.php
+++ b/modules/create_course/functions.php
@@ -105,6 +105,7 @@ function create_course_dirs($code) {
             Session::Messages(sprintf($langDirectoryCreateError, $dir));
             return false;
        } 
+       chmod($dir, 0755);
     }
     umask($old_umask);
     return true;


### PR DESCRIPTION
Change folders permissions to 0755 at create_course_dirs function to prevent Apache security error: "SoftException in Application.cpp:603: Directory ... is writeable by group, referer ... "