### PR TITLE
Add autofocus to the default user login form

### DIFF
--- a/main/login_form.php
+++ b/main/login_form.php
@@ -45,7 +45,7 @@ foreach ($q as $l) {
             $next
             <div class='form-group'>
               <div class='col-xs-12'>
-                <input class='form-control' name='uname' placeholder='$langUsername'$userValue>
+                <input autofocus class='form-control' name='uname' placeholder='$langUsername'$userValue>
               </div>
             </div>
             <div class='form-group'>


### PR DESCRIPTION
I tend to avoid using my mouse because the keyboard is faster, so I found it quite annoying having to manually click on the username field in order to login to my eclass account (which usually happens more than once per day).