### PR TITLE
refactor: clean-up dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,17 @@
-# syntax=docker/dockerfile:1
+FROM php:8.2-apache-trixie AS base
 
-# Used to copy what we need
-FROM alpine as base
-RUN mkdir -p /var/www/html
-COPY . /var/www/html/
-RUN rm -rf /var/www/html/docker
+ARG INSTALL_DIR="/var/www/html"
+ARG COMPOSER_CACHE_DIR="/tmp/composer"
 
-FROM php:8.2-apache
+RUN mkdir -p ${INSTALL_DIR}
+COPY . ${INSTALL_DIR}
+COPY docker/php/php.ini ${PHP_INI_DIR}/php.ini
 
-LABEL gr.gunet.e-class-docker.maintainer="eclass@gunet.gr"
-LABEL org.opencontainers.image.source="https://github.com/gunet/openeclass"
-LABEL org.opencontainers.image.description="Open e-Class Docker image"
-
-RUN apt-get update && apt-get install -yq --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y --no-install-recommends \
     default-libmysqlclient-dev \
     libbz2-dev \
     libmemcached-dev \
     libsasl2-dev \
-    curl \
-    git \
     libfreetype6-dev \
     libicu-dev \
     libjpeg-dev \
@@ -28,46 +21,43 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     libpq-dev \
     libxml2-dev \
     libzip-dev \
-    vim-tiny && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+    git && \
+    apt clean
 
 RUN docker-php-ext-install iconv intl mysqli opcache pdo_mysql pdo_pgsql zip gd ldap soap
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 RUN a2disconf charset localized-error-pages serve-cgi-bin && \
     a2dismod -f access_compat autoindex deflate negotiation status
 
-COPY docker/php/ ${PHP_INI_DIR}/
+RUN mkdir -p ${COMPOSER_CACHE_DIR}
 
-ARG INSTALL=/var/www/html
+RUN cd ${INSTALL_DIR} && \
+    COMPOSER_CACHE_DIR=${COMPOSER_CACHE_DIR} composer update && \
+    COMPOSER_CACHE_DIR=${COMPOSER_CACHE_DIR} composer install
 
-COPY --from=base --chown=www-data:www-data /var/www/html/ ${INSTALL}/
+RUN mkdir -p ${INSTALL_DIR}/config ${INSTALL_DIR}/courses ${INSTALL_DIR}/video
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
-USER www-data
-RUN cd /var/www/html && \
-    COMPOSER_CACHE_DIR=/var/www/html/.cache composer update && \
-    COMPOSER_CACHE_DIR=/var/www/html/.cache composer install && \
-    rm -rf /var/www/html/.cache
+RUN chown -R www-data:www-data ${INSTALL_DIR}
 
-RUN mkdir ${INSTALL}/config && \
-    mkdir ${INSTALL}/courses && \
-    mkdir ${INSTALL}/video
-    # chown -R www-data:www-data ${INSTALL}/
-USER root
+LABEL gr.gunet.e-class-docker.maintainer="eclass@gunet.gr"
+LABEL org.opencontainers.image.source="https://github.com/gunet/openeclass"
+LABEL org.opencontainers.image.description="Open e-Class Docker image"
 
-HEALTHCHECK --interval=10s --timeout=3s --start-period=3s --retries=5 \
-    CMD pgrep -u www-data -c apache2
-
-WORKDIR ${INSTALL}
-
-EXPOSE 80
-
+# Admin password is randomly generated. Othewise can be set with env var
+# ADMIN_PASSWORD
 ENV TZ=Europe/Athens
 ENV MYSQL_LOCATION=db
 ENV MYSQL_ROOT_USER=root
 ENV MYSQL_ROOT_PASSWORD=secret
 ENV MYSQL_DB=eclass
 ENV ADMIN_USERNAME=admin
-# Admin password is randomly generated. Othewise can be set with env var
-# ADMIN_PASSWORD
 ENV PHP_MAX_UPLOAD=256M
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=3s --retries=5 \
+    CMD pgrep -u www-data -c apache2
+
+EXPOSE 80
+
+VOLUME ["${INSTALL_DIR}/config", "${INSTALL_DIR}/courses", "${INSTALL_DIR}/video"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,45 +1,47 @@
 services:
-    eclass:
-        image: ghcr.io/gunet/openeclass
-        depends_on:
-            db:
-                condition: service_healthy
-        ports:
-            - "80:80"
-        volumes:
-            - config_data:/var/www/html/config
-            - courses_data:/var/www/html/courses
-            - video_data:/var/www/html/video
-        environment:
-            - MYSQL_LOCATION=db
-            - MYSQL_ROOT_USER=root
-            - MYSQL_ROOT_PASSWORD=secret
-            - MYSQL_DB=eclass
-            - ADMIN_USERNAME=admin
-            # Can be used to set the admin password
-            # - ADMIN_PASSWORD=secret
-            - PHP_MAX_UPLOAD=256M
-    db:   # The location of the database
-        image: mariadb:10.11
-        environment:
-            - MYSQL_ROOT_PASSWORD=secret
-            - MYSQL_DATABASE=eclass
-        command:
-        - --innodb-buffer-pool-size=120M
-        - --innodb_flush_log_at_trx_commit=2
-        - --wait-timeout=86400
-        - --max_allowed_packet=67108864
-        volumes:
-            - db_data:/var/lib/mysql
-        healthcheck:
-            test: mysql --user=root --password=$$MYSQL_ROOT_PASSWORD -e 'show databases;' | grep -q $$MYSQL_DATABASE || exit 1
-            interval: 10s
-            timeout: 3s
-            retries: 10
-            start_period: 5s
+  eclass:
+    image: ghcr.io/gunet/openeclass
+    restart: unless-stopped
+    ports:
+      - 80:80
+    volumes:
+      - config_data:/var/www/html/config
+      - courses_data:/var/www/html/courses
+      - video_data:/var/www/html/video
+    environment:
+      - MYSQL_LOCATION=db
+      - MYSQL_ROOT_USER=root
+      - MYSQL_ROOT_PASSWORD=secret
+      - MYSQL_DB=eclass
+      - ADMIN_USERNAME=admin
+      # Can be used to set the admin password
+      # - ADMIN_PASSWORD=secret
+      - PHP_MAX_UPLOAD=256M
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mariadb:10.11
+    environment:
+      - MYSQL_ROOT_PASSWORD=secret
+      - MYSQL_DATABASE=eclass
+    command:
+      - --innodb-buffer-pool-size=120M
+      - --innodb_flush_log_at_trx_commit=2
+      - --wait-timeout=86400
+      - --max_allowed_packet=67108864
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: mysql --user=root --password=$$MYSQL_ROOT_PASSWORD -e 'show databases;' | grep -q $$MYSQL_DATABASE || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
 
 volumes:
-    config_data:
-    courses_data:
-    video_data:
-    db_data:
+  config_data:
+  courses_data:
+  video_data:
+  db_data:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,15 +1,17 @@
-Open e-Class Docker image
+# Open e-Class Docker image
 
-Base image is `php:8.2-apache`
+Base image is `php:8.2-apache-trixie` and `composer:2` is used for the `composer` binary.
 
 # Run
-* All commands should be run in the root Open e-Class folder
-* Build: `docker compose -f docker-compose.build.yaml build`
-* Run stack: `docker compose up -d`
-* Run stack with SimpleIdentity (SSO & LDAP): `docker compose -f docker-compose.yaml -f docker-compose.test.yaml up -d`
+
+- All commands should be run in the root Open e-Class folder
+- Build: `docker compose -f docker-compose.build.yaml build`
+- Run stack: `docker compose up -d`
+- Run stack with SimpleIdentity (SSO & LDAP): `docker compose -f docker-compose.yaml -f docker-compose.test.yaml up -d`
 
 # Environment Variables
-* The variables below can be set in the `docker-compose.yaml` file
+
+- The variables below can be set in the `docker-compose.yaml` file
   - `MYSQL_LOCATION`: The DB location, used as default value when setting up a new installation. Should be left to the default value of `db` which is the service name of the `db` MariaDB container
   - `MYSQL_ROOT_USER`: The default of `root` is fine
   - `MYSQL_ROOT_PASSWORD`: The MariaDB root password to use to connect. Should be left to the default value of `secret`. Only containers in the Docker Compose stack have access to the MariaDB container, no SQL port is exposed to the outside world.
@@ -19,9 +21,10 @@ Base image is `php:8.2-apache`
   - `PHP_MAX_UPLOAD`: The maximum file that can be uploaded. The default value is `256M`
 
 # Size
-* Docker image
-  - e-Class: `1 GB`
+
+- Docker image
+  - e-Class: `1.5 GB`
   - MariaDB: `400 MB`
-* Memory usage
+- Memory usage
   - e-Class: `50 MB`
   - MariaDB: `150 MB`


### PR DESCRIPTION
This pull-request organizes and cleans up the `Dockerfile` for better readability and maintainability. The following changes were made:

- Remove use of the `alpine` image since it was only used to copy the source code
- Use tagged `composer` and `php` versions to avoid breaking distro or software updates
- Remove unnecessary packages like `curl` and `vim-tiny`
- Organize the `Dockerfile` in a source code, dependencies, config, runtime model improving readability
- Create volumes for the `config`, `courses` and `video` directories ensuring configuration persistence even if the end-user forgets to assign a named volume

Ideally the Debian based PHP image should be replaced with [8.3-alpine3.21](https://hub.docker.com/layers/library/php/8.3-alpine3.21/images/sha256-c4c9898d4be554ed421a8db7ddc3eb3b07d708e979bfbb2a350e35995520c036) which would offer a far more lightweight image but I decided against it for now to avoid breaking any current setups that rely on Debian. Let me know if you need anything changed.