### PR TITLE
feat: add AM and department to course user request email, make message optional

### DIFF
--- a/modules/contact/index.php
+++ b/modules/contact/index.php
@@ -184,7 +184,8 @@ function form($user) {
  */
 function email_profs($course_id, $content, $from_name, $from_username, $from_address, $from_am, $from_department) {
     global $langSendingMessage, $langLabelCourseUserRequest, $langContactIntro,
-            $langHere, $urlServer, $langNote, $langMessage, $langContactIntroFooter;
+            $langHere, $urlServer, $langNote, $langMessage, $langContactIntroFooter,
+			$langAm, $langFaculty;
 
     $c_code = course_id_to_code($course_id);
     $title = course_id_to_title($course_id);


### PR DESCRIPTION
As a student who actively uses eClass on a daily basis, I came across two 
issues with the course user request form that I think would improve the 
experience for both students and professors.

First, the form currently requires students to write a message before 
submitting a request. In many cases, students simply want to request access 
to a course without necessarily having something specific to say, so I made 
the message field optional.

Second, when a professor receives an email notification about a student's 
request, it only contains the student's name and username. This makes it 
difficult for professors to identify who the student is. I added the student's 
AM (registration number) and department to the email, which are useful 
pieces of information for a professor to have.