### PR TITLE
Disallow guest user from accessing Personal Documents

### DIFF
--- a/modules/document/index.php
+++ b/modules/document/index.php
@@ -335,6 +335,9 @@ if (defined('COMMON_DOCUMENTS')) {
     $toolName = $langCommonDocs;
     $diskQuotaDocument = $diskUsed + parseSize(ini_get('upload_max_filesize'));
 } elseif (defined('MY_DOCUMENTS')) {
+    if ($session->status == USER_GUEST) {
+        redirect_to_home_page();
+    }
     if ($session->status == USER_TEACHER and !get_config('mydocs_teacher_enable')) {
         redirect_to_home_page();
     }


### PR DESCRIPTION
This is a simple fix for a bug that allows a guest user to access the "Personal Documents" page. This shouldn't be possible normally and happens even if the "Personal Documents" feature is disabled by the config.