### PR TITLE
Dockerfile: copy modules dir in bun_stage for postinstall script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY --from=composer_stage /app/vendor ./vendor
 # Copy needed app files
 COPY js js
 COPY include include
+COPY modules modules
 COPY package.json .
 # Install JS dependencies and run postinstall script (php ./js/build/build.php)
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- `docker compose -f docker-compose.build.yaml build` fails because the postinstall script
  `php ./js/build/build.php` requires `modules/admin/tenant_functions.php`, but the `bun_stage`
  only copied `js/` and `include/` — not `modules/`.
- Fixed by adding `COPY modules modules` in the `bun_stage` before `bun install --frozen-lockfile`.

## Error

$ php ./js/build/build.php
PHP Warning:  require_once(modules/admin/tenant_functions.php): Failed to open stream: No such file or directory in /app/include/lib/hierarchy.class.php on line 21
PHP Fatal error:  Uncaught Error: Failed opening required 'modules/admin/tenant_functions.php' (include_path='.:/usr/share/php') in /app/include/lib/hierarchy.class.php:21
Stack trace:
#0 /app/include/main_lib.php(39): require_once()
#1 /app/js/build/build.php(4): require_once('...')
#2 {main}
thrown in /app/include/lib/hierarchy.class.php on line 21
error: postinstall script from "open-eclass" exited with 255



## Fix

Added `COPY modules modules` to the `bun_stage` in `Dockerfile`:

```dockerfile
# Copy needed app files
COPY js js
COPY include include
COPY modules modules   # <-- added
COPY package.json .
How to verify

docker compose -f docker-compose.build.yaml build
Build should complete successfully.