### PR TITLE
mobile: recover expired session in app WebView via sentinel redirect

### DIFF
--- a/include/init.php
+++ b/include/init.php
@@ -314,6 +314,12 @@ if (file_exists("template/$theme/settings.php")) {
 }
 
 if (isset($require_login) and $require_login and ! $uid) {
+    // Mobile app WebView: a session that expired while a page was open would otherwise show the web
+    // "session lost" message, unrelated to the app flow. Redirect to the session-expired sentinel so
+    // the app can silently refresh the session and return the user to the same page.
+    if (isset($_SERVER['HTTP_USER_AGENT']) and str_contains($_SERVER['HTTP_USER_AGENT'], 'eClassMobileApp')) {
+        redirect_to_home_page('modules/mobile/msession_expired.php?return=' . urlencode($urlServer . ltrim($_SERVER['REQUEST_URI'], '/')));
+    }
     $toolContent_ErrorExists = $langSessionIsLost;
 }
 

--- a/modules/mobile/minit.php
+++ b/modules/mobile/minit.php
@@ -46,8 +46,15 @@ if (isset($require_mlogin) && $require_mlogin) {
     }
 
     if (!isset($_SESSION['uid'])) {
-        echo RESPONSE_EXPIRED;
         session_regenerate_id();
+        // Mobile app WebView flow (carries a redirect target): instead of returning the raw
+        // EXPIRED response — which the embedded WebView renders as an error page — redirect to the
+        // session-expired sentinel so the app can silently refresh the session and retry.
+        if (isset($_REQUEST['redirect'])) {
+            header('Location: msession_expired.php?return=' . urlencode($_REQUEST['redirect']));
+            exit();
+        }
+        echo RESPONSE_EXPIRED;
         exit();
     }
 }

--- a/modules/mobile/msession_expired.php
+++ b/modules/mobile/msession_expired.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ *  ========================================================================
+ *  * Open eClass
+ *  * E-learning and Course Management System
+ *  * ========================================================================
+ *  * Copyright 2003-2024, Greek Universities Network - GUnet
+ *  *
+ *  * Open eClass is an open platform distributed in the hope that it will
+ *  * be useful (without any warranty), under the terms of the GNU (General
+ *  * Public License) as published by the Free Software Foundation.
+ *  * The full license can be read in "/info/license/license_gpl.txt".
+ *  *
+ *  * Contact address: GUnet Asynchronous eLearning Group
+ *  *                  e-mail: info@openeclass.org
+ *  * ========================================================================
+ *
+ */
+
+/*
+ * Session-expired sentinel for the mobile app WebView.
+ *
+ * When a mobile app WebView request hits an expired session, the auth layer redirects here
+ * (mlogin.php for the login-exchange flow, init.php for an already-open page). The app detects
+ * this URL, silently refreshes its token and re-enters, so the user normally never sees this page.
+ *
+ * The content below is only a fallback for older app versions that do not perform that
+ * interception; it is a plain, public, dependency-free page (no auth) that always returns 200.
+ */
+
+header('Content-Type: text/html; charset=utf-8');
+
+?><!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Η συνεδρία έληξε</title>
+    <style>
+        body { margin: 0; font-family: -apple-system, Roboto, Helvetica, Arial, sans-serif;
+               background: #f4f6f8; color: #333; display: flex; min-height: 100vh;
+               align-items: center; justify-content: center; }
+        .box { max-width: 420px; padding: 32px 24px; text-align: center; }
+        h1 { font-size: 20px; margin: 0 0 12px; }
+        p { font-size: 15px; line-height: 1.5; margin: 0; color: #666; }
+    </style>
+</head>
+<body>
+    <div class="box">
+        <h1>Η συνεδρία έληξε</h1>
+        <p>Επιστρέψτε στην εφαρμογή για να ανανεωθεί η σύνδεσή σας.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Problem

When the mobile app opens an eClass page inside its WebView, it POSTs the session token (plus a `redirect` target) to `modules/mobile/mlogin.php`, which turns the token into a web session and redirects to the page. Two cases break once the session has expired:

1. **Expired before opening a page** — `mlogin.php` (through `minit.php`) finds the session expired and returns the raw `EXPIRED` body with `Content-Type: application/xml`. The embedded WebView renders this as an "invalid XML" error.
2. **Expired while a page is already open** — the user leaves a page open, the web session expires, and the next click shows the web "session lost" message (`$langSessionIsLost`), unrelated to the app flow.

Note: `mlogin.php` sets `session_id($_POST['token'])`, so the web session cookie **is** the mobile token — API and web session expire together.

## Change

Redirect app WebView requests that hit an expired session to a new, stable sentinel page — `modules/mobile/msession_expired.php` — carrying the originally requested URL as a `return` parameter. The app recognizes this URL, silently refreshes its session, and re-enters via `mlogin.php` with `redirect=<return>`, landing the user back where they were.

- **`modules/mobile/minit.php`** — on expiry, if a `redirect` target is present (the WebView login-exchange flow), redirect to the sentinel instead of echoing `EXPIRED`. Genuine mobile API calls (`mportfolio`/`mtools`/`munits`) send no `redirect` and keep receiving the `EXPIRED` XML response unchanged.
- **`include/init.php`** — on `require_login` failure, if the request comes from the app WebView (User-Agent contains the `eClassMobileApp` marker the app appends), redirect to the sentinel with the current URL as `return`, instead of setting the "session lost" message.
- **`modules/mobile/msession_expired.php`** — new public page (no auth, always `200`) with a small fallback message. Newer app versions intercept the URL before it renders; the content is only a graceful fallback for older app versions during rollout.

## Compatibility

- No behavior change for regular browsers or for the existing mobile API endpoints.
- The app appends `eClassMobileApp` to its WebView User-Agent and handles the sentinel URL; institutions pick up the server change through the normal upgrade path.